### PR TITLE
config: Added configuration options for scheduler and allocator

### DIFF
--- a/src/config/fts3config
+++ b/src/config/fts3config
@@ -171,3 +171,9 @@ LogLevel=INFO
 # New naming convention: /tmp/x509up_h<hash>_<delegation_id>
 # Backwards compatible naming: /tmp/x509up_h<hash><encodedDN>
 #BackwardsCompatibleProxyNames = False
+
+# Specify the transfer service's slot allocation algorithm as MAXFLOW or GREEDY (default GREEDY)
+TransferServiceAllocatorAlgorithm = GREEDY
+
+# Specify transfer service's task scheduling algorithm as RANDOMIZED, DEFICIT, or SELECTION
+TransferServiceSchedulingAlgorithm = RANDOMIZED

--- a/src/config/serverconfigreader.cpp
+++ b/src/config/serverconfigreader.cpp
@@ -46,6 +46,8 @@ using namespace fts3::config;
 #define FTS3_CONFIG_SERVERCONFIG_MED_SUCCESS_RATE_DEFAULT 98
 #define FTS3_CONFIG_SERVERCONFIG_LOW_SUCCESS_RATE_DEFAULT 97
 #define FTS3_CONFIG_SERVERCONFIG_BASE_SUCCESS_RATE_DEFAULT 96
+#define FTS3_CONFIG_SERVERCONFIG_TRANSFER_SERVICE_ALLOCATOR_ALGORITHM "GREEDY"
+#define FTS3_CONFIG_SERVERCONFIG_TRANSFER_SERVICE_SCHEDULING_ALGORITHM "RANDOMIZED"
 /* ---------------------------------------------------------------------- */
 
 po::options_description ServerConfigReader::_defineGenericOptions()
@@ -508,6 +510,21 @@ po::options_description ServerConfigReader::_defineConfigOptions()
         po::value<std::string>( &(_vars["ExperimentalTapeRESTAPI"]) )->default_value("false"),
         "Enable or disable experimental features of the TAPE REST API"
     )
+    (
+        "",
+        po::value<std::string>( &(_vars["ExperimentalTapeRESTAPI"]) )->default_value("false"),
+        "Enable or disable experimental features of the TAPE REST API"
+    )
+    (
+        "TransferServiceAllocatorAlgorithm",
+        po::value<std::string>( &(_vars["TransferServiceAllocatorAlgorithm"]) )->default_value(FTS3_CONFIG_SERVERCONFIG_TRANSFER_SERVICE_ALLOCATOR_ALGORITHM),
+        "Specify transfer service's slot allocation algorithm as MAXFLOW or GREEDY"
+    )
+    (
+        "TransferServiceSchedulingAlgorithm",
+        po::value<std::string>( &(_vars["TransferServiceSchedulingAlgorithm"]) )->default_value(FTS3_CONFIG_SERVERCONFIG_TRANSFER_SERVICE_SCHEDULING_ALGORITHM),
+        "Specify transfer service's task scheduling algorithm as RANDOMIZED, DEFICIT, or SELECTION"
+    )
     ;
 
     return config;
@@ -641,6 +658,8 @@ void ServerConfigReader::storeValuesAsStrings ()
     storeAsString("OptimizerIncreaseStep");
     storeAsString("OptimizerAggressiveIncreaseStep");
     storeAsString("OptimizerDecreaseStep");
+    storeAsString("TransferServiceAllocatorAlgorithm");
+    storeAsString("TransferServiceSchedulingAlgorithm");
 }
 
 void ServerConfigReader::storeRoles ()

--- a/test/unit/config/ServerConfigReader.cpp
+++ b/test/unit/config/ServerConfigReader.cpp
@@ -45,6 +45,17 @@ BOOST_FIXTURE_TEST_CASE (functionOperator, fts3::config::ServerConfigReader)
     BOOST_CHECK_EQUAL(_vars["SiteName"], std::string("required"));
 }
 
+BOOST_FIXTURE_TEST_CASE (transferOperator, fts3::config::ServerConfigReader)
+{
+    std::vector<const char*> args{
+            "executable", "--configfile=/dev/null",
+            "--TransferServiceAllocator=MAXFLOW", "--TransferServiceScheduler=DEFICIT"
+    };
+
+    (*this)(args.size(), (char**)args.data());
+    BOOST_CHECK_EQUAL(_vars["TransferServiceAllocator"], std::string("MAXFLOW"));
+    BOOST_CHECK_EQUAL(_vars["TransferServiceScheduler"], std::string("DEFICIT"));
+}
 
 // Test class for DbType options.
 struct TestDbTypeServerConfigReader : public fts3::config::ServerConfigReader
@@ -97,6 +108,9 @@ BOOST_FIXTURE_TEST_CASE (functionOperatorFromFile, fts3::config::ServerConfigRea
     file << "DbUserName=" << f_str << std::endl;
     file << "DbPassword=" << f_str << std::endl;
     file << "TransferLogDirectory=" << f_str << std::endl;
+    file << "ThreadNum=" << f_intval << std::endl;
+    file << "TransferServiceSchedulingAlgorithm=" << f_intval << std::endl;
+    file << "TransferServiceAllocatorAlgorithm=" << f_intval << std::endl;
     file << "ThreadNum=" << f_intval << std::endl;
     file.close();
 


### PR DESCRIPTION
Added new configuration for selecting the transfer service's allocator as "GREEDY" or "MAXFLOW", with default being "GREEDY". Also added configuration for selecting the transfer service's scheduling algorithm as "RANDOMIZED", "DEFICIT", or "SELECTION", with the default value being "RANDOMIZED". User's are able to override these default values via the command line.