### PR TITLE
FTS3 Concurrent Optimizer

### DIFF
--- a/src/config/serverconfigreader.cpp
+++ b/src/config/serverconfigreader.cpp
@@ -254,6 +254,16 @@ po::options_description ServerConfigReader::_defineConfigOptions()
         "Set the number of threads in the internal threadpool"
     )
     (
+        "OptimizerThreadPool",
+        po::value<std::string>( &(_vars["OptimizerThreadPool"]) )->default_value("5"),
+        "Set the number of threads in the optimizer threadpool"
+    )
+    (
+        "ParallelizeOptimizer",
+        po::value<std::string>( &(_vars["ParallelizeOptimizer"]) )->default_value("false"),
+        "Enable or disable the parallelization of the Optimizer decision making for each source-destination pair"
+    )
+    (
         "CleanBulkSize",
         po::value<std::string>( &(_vars["CleanBulkSize"]) )->default_value("5000"),
         "Set the bulk size, in number of jobs, used for cleaning the old records"

--- a/src/server/services/optimizer/Optimizer.h
+++ b/src/server/services/optimizer/Optimizer.h
@@ -28,6 +28,7 @@
 #include <boost/noncopyable.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/timer/timer.hpp>
+#include <boost/thread/shared_mutex.hpp>
 #include <db/generic/LinkConfig.h>
 #include <db/generic/Pair.h>
 #include <msg-bus/producer.h>
@@ -142,11 +143,12 @@ protected:
     int maxSuccessRate;
     int lowSuccessRate;
     int baseSuccessRate;
-
     int decreaseStepSize;
     int increaseStepSize, increaseAggressiveStepSize;
     double emaAlpha;
-
+    int optimizerPoolSize;
+    bool parallelizeOptimizer;
+    static boost::shared_mutex mx;
     // Run the optimization algorithm for the number of connections.
     // Returns true if a decision is stored
     bool optimizeConnectionsForPair(OptimizerMode optMode, const Pair &);
@@ -161,6 +163,7 @@ protected:
     void setOptimizerDecision(const Pair &pair, int decision, const PairState &current,
         int diff, const std::string &rationale, boost::timer::cpu_times elapsed);
 
+    bool updateIfPairExist(const Pair& pair, PairState& current);
 public:
     Optimizer(OptimizerDataSource *ds, OptimizerCallbacks *callbacks);
     ~Optimizer();
@@ -172,6 +175,9 @@ public:
     void setBaseSuccessRate(int);
     void setStepSize(int increase, int increaseAggressive, int decrease);
     void setEmaAlpha(double);
+    void setPoolSize(int);
+    void setParallelizeOptimizer(bool);
+
     void run(void);
     void runOptimizerForPair(const Pair&);
 };

--- a/src/server/services/optimizer/OptimizerPair.h
+++ b/src/server/services/optimizer/OptimizerPair.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) CERN 2013-2016
+ *
+ * Copyright (c) Members of the EMI Collaboration. 2010-2013
+ *  See  http://www.eu-emi.eu/partners for details on the copyright
+ *  holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FTS3_OPTIMIZERPAIR_H
+#define FTS3_OPTIMIZERPAIR_H
+
+
+#include <boost/any.hpp>
+#include <db/generic/Pair.h>
+
+
+namespace fts3 {
+namespace optimizer {
+
+class OptimizerPair {
+public:
+    Pair pair;
+    Optimizer* optimizer;
+
+    OptimizerPair(const Pair& pair, Optimizer* optimizer) : pair(pair), optimizer(optimizer) {}
+
+    void run(boost::any& ctx) {
+        if (ctx.empty()) {
+            ctx = 0;
+        }
+        int &numPairs = boost::any_cast<int &>(ctx);
+
+        if (boost::this_thread::interruption_requested()) {
+            return;
+        }
+        optimizer->runOptimizerForPair(pair);
+
+        numPairs += 1;
+    }
+};
+
+}
+}
+
+#endif // OPTIMIZERPAIR_H_

--- a/src/server/services/optimizer/OptimizerService.cpp
+++ b/src/server/services/optimizer/OptimizerService.cpp
@@ -97,6 +97,8 @@ void OptimizerService::runService()
     auto increaseStep = config::ServerConfig::instance().get<int>("OptimizerIncreaseStep");
     auto increaseAggressiveStep = config::ServerConfig::instance().get<int>("OptimizerAggressiveIncreaseStep");
     auto decreaseStep = config::ServerConfig::instance().get<int>("OptimizerDecreaseStep");
+    auto poolSize = config::ServerConfig::instance().get<int>("OptimizerThreadPool");
+    auto parallelizationEnabled = config::ServerConfig::instance().get<bool>("ParallelizeOptimizer");
 
     OptimizerNotifier optimizerCallbacks(
         config::ServerConfig::instance().get<bool>("MonitoringMessaging"),
@@ -114,6 +116,8 @@ void OptimizerService::runService()
     optimizer.setBaseSuccessRate(baseSuccessRate);
     optimizer.setEmaAlpha(emaAlpha);
     optimizer.setStepSize(increaseStep, increaseAggressiveStep, decreaseStep);
+    optimizer.setPoolSize(poolSize);
+    optimizer.setParallelizeOptimizer(parallelizationEnabled);
 
     while (!boost::this_thread::interruption_requested()) {
         try {

--- a/src/server/services/optimizer/OptimizerStreams.cpp
+++ b/src/server/services/optimizer/OptimizerStreams.cpp
@@ -33,6 +33,7 @@ namespace optimizer {
 // This part of the algorithm will check how to split the number of connections
 // between the number of available transfers.
 // Basically, divide the number of connections between the number of queued+active
+
 void Optimizer::optimizeStreamsForPair(OptimizerMode optMode, const Pair &pair)
 {
     // No optimization for streams, so go for 1
@@ -40,7 +41,7 @@ void Optimizer::optimizeStreamsForPair(OptimizerMode optMode, const Pair &pair)
         dataSource->storeOptimizerStreams(pair, 1);
         return;
     }
-
+    boost::shared_lock<boost::shared_mutex> lock(mx);
     auto state = inMemoryStore[pair];
 
     int connectionsAvailable = state.connections;


### PR DESCRIPTION
Parallelize the decision making of source-destination pair concurrency within the Optimizer. 

We utilize the existing ThreadPool class found [here](https://github.com/jackiedong6/fts3/blob/master/src/common/ThreadPool.h), and follow its utilization [here](https://github.com/jackiedong6/fts3/blob/1e92a6969912cd4098c4bba88f0ed7ac72402e6a/src/server/services/transfers/TransfersService.cpp#L110-L248). 

We also modify OptimizerDatasource to ensure that each thread has a separate database session while also locking the shared `inMemoryMap` of the Optimizer.  